### PR TITLE
Remove rake stuff

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,6 @@ gem 'puma', '~> 5.0'
 
 # use active record
 gem 'sinatra-activerecord'
-# use rake
-gem "rake"
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,6 @@ DEPENDENCIES
   i18n
   pry
   puma (~> 5.0)
-  rake
   rspec
   rspec-html-matchers
   sinatra

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,0 @@
-require "sinatra/activerecord/rake"
-
-namespace :db do
-  task :load_config do
-    require "./config/environment.rb"
-  end
-end


### PR DESCRIPTION
We actually don't need to include `rake db:` tasks to generate tables and run database migrations, it can be done by making plain ol' Ruby files in `db/migrate/`.

This will also work with Fly deployment.