### PR TITLE
Add erb commenter extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,8 @@
       "extensions": ["vortizhe.simple-ruby-erb",
                      "mbessey.vscode-rufo",
                      "aliariff.vscode-erb-beautify",
-                     "eamodio.gitlens"]
+                     "eamodio.gitlens",
+                     "setobiralo.erb-commenter"]
     }
   }
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -29,3 +29,4 @@ vscode:
     - mbessey.vscode-rufo
     - aliariff.vscode-erb-beautify
     - eamodio.gitlens
+    - setobiralo.erb-commenter


### PR DESCRIPTION
In codespaces, .erb files are not adding comments with the keyboard shortcut. This added extension solves the problem:

https://marketplace.visualstudio.com/items?itemName=setobiralo.erb-commenter

If it works and this PR is approved, I'll add the extension to the `devcontainer.json` and `gitpod.yml` file in all projects and templates. But that does make we wonder: Could we just add this extension in the Dockerfile? That would solve the problem of requiring updates across all projects anytime we add / drop a VSCode extension..